### PR TITLE
Project data may not have max_devices

### DIFF
--- a/packet/Project.py
+++ b/packet/Project.py
@@ -9,7 +9,7 @@ class Project(BaseAPI):
         self.id = data['id']
         self.name = data['name']
         self.payment_method = data['payment_method']
-        self.max_projects = data['max_devices']
+        self.max_projects = data.get('max_devices')
         self.created_at = data['created_at']
         self.updated_at = data['updated_at']
         self.devices = data['devices']


### PR DESCRIPTION
max_devices is no longer returned from a GET to /projects/<id>. This allows project lookups to still work.