### PR TITLE
improve quality of API error message in unhandled exception

### DIFF
--- a/packet/baseapi.py
+++ b/packet/baseapi.py
@@ -63,14 +63,9 @@ class BaseAPI(object):
                 )
         except requests.exceptions.RequestException as e:
             raise Error('Communcations error: %s' % str(e), e)
-        try:
-            resp.raise_for_status()
-        except requests.HTTPError as e:
-            raise Error('Error {0}: {1}'.format(resp.status_code,
-                                                resp.reason), e)
         if not resp.content:
             data = None
-        elif resp.headers['content-type'].startswith("application/json"):
+        elif resp.headers.get("content-type","").startswith("application/json"):
             try:
                 data = resp.json()
             except ValueError as e:
@@ -89,6 +84,11 @@ class BaseAPI(object):
             raise Error(
                 'Error {0}: {1}'.format(resp.status_code, msg)
             )
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as e:
+            raise Error('Error {0}: {1}'.format(resp.status_code,
+                                                resp.reason), e)
         self.meta = None
         try:
             if data and data['meta']:

--- a/packet/baseapi.py
+++ b/packet/baseapi.py
@@ -65,7 +65,7 @@ class BaseAPI(object):
             raise Error('Communcations error: %s' % str(e), e)
         if not resp.content:
             data = None
-        elif resp.headers.get("content-type","").startswith("application/json"):
+        elif resp.headers.get("content-type", "").startswith("application/json"):
             try:
                 data = resp.json()
             except ValueError as e:


### PR DESCRIPTION
This fixes handling of errors in the Python API client, and consequently the quality of displayed error message from exception. Before, this PR, an attempt to remove device in provisioning state would result in
```
Traceback (most recent call last):
  File "./pa.py", line 28, in <module>
    pc.call_api("devices/%s" % d.id, type='DELETE')
  File "/home/tomk/packet-python/packet/Manager.py", line 18, in call_api
    return super(Manager, self).call_api(method, type, params)  # pragma: no cover
  File "/home/tomk/packet-python/packet/baseapi.py", line 70, in call_api
    resp.reason), e)
packet.baseapi.Error: Error 422: Unprocessable Entity
```

after this PR, it results in 
```
Traceback (most recent call last):
  File "./pa.py", line 28, in <module>
    pc.call_api("devices/%s" % d.id, type='DELETE')
  File "/home/tomk/packet-python/packet/Manager.py", line 18, in call_api
    return super(Manager, self).call_api(method, type, params)  # pragma: no cover
  File "/home/tomk/packet-python/packet/baseapi.py", line 85, in call_api
    'Error {0}: {1}'.format(resp.status_code, msg)
packet.baseapi.Error: Error 422: Cannot delete a device while it is provisioning
```

Plus, I made the API client not to fail if the Content-type header is omitted from the response.