### PR TITLE
add public_ipv4_subnet_size option to create_device

### DIFF
--- a/packet/Manager.py
+++ b/packet/Manager.py
@@ -72,7 +72,8 @@ class Manager(BaseAPI):
 
     def create_device(self, project_id, hostname, plan, facility,
                       operating_system, billing_cycle='hourly', userdata='',
-                      locked=False, tags={}, features={}, ipxe_script_url='', always_pxe=False):
+                      locked=False, tags={}, features={}, ipxe_script_url='',
+                      always_pxe=False, public_ipv4_subnet_size=31):
 
         params = {
             'hostname': hostname,
@@ -84,6 +85,7 @@ class Manager(BaseAPI):
             'userdata': userdata,
             'locked': locked,
             'features': features,
+            'public_ipv4_subnet_size': public_ipv4_subnet_size,
             'tags': tags,
         }
 


### PR DESCRIPTION
Add options for IPv4 subnet size to Packet Python API client, in order to add this option to Ansible module.

More doc about the feature:
https://help.packet.net/technical/networking/custom-subnet-size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packet-python/27)
<!-- Reviewable:end -->
