### PR TITLE
Only require pyparsing when converting readme and changelog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import pypandoc
 
 # Notes for the not-an-everyday-python-dev for package distribution on pypi
 #
@@ -45,10 +44,15 @@ except ImportError:
     from setuptools import setup
 
 long_description = 'This library provides the python client for the Packet API.'
+
+setup_requires = []
+
 if os.path.isfile('README.md') and os.path.isfile('CHANGELOG.md'):
+    import pypandoc
     readme = pypandoc.convert_file('README.md', 'rst')
     changelog = pypandoc.convert_file('CHANGELOG.md', 'rst')
     long_description = readme + '\n' + changelog
+    setup_requires.append('pyparsing')
 
 setup(
     name='packet-python',
@@ -61,7 +65,7 @@ setup(
     keywords='packet api client',
     packages=['packet'],
     install_requires='requests',
-    setup_requires='pypandoc',
+    setup_requires=setup_requires,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Possible solution to https://github.com/packethost/packet-python/issues/34.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packet-python/35)
<!-- Reviewable:end -->
