### PR TITLE
Manager: add `legacy` optional param to get_capacity

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include CHANGELOG.md
+include README.md

--- a/packet/Manager.py
+++ b/packet/Manager.py
@@ -168,6 +168,16 @@ class Manager(BaseAPI):
         return Volume(data, self)
 
     def get_capacity(self, legacy=None):
+        """Get capacity of all facilities.
+
+        :param legacy: Indicate set of server types to include in response
+
+        Validation of `legacy` is left to the packet api to avoid going out of date if any new value is introduced.
+        The currently known values are:
+          - only (current default, will be switched "soon")
+          - include
+          - exclude (soon to be default)
+        """
         params = None
         if legacy:
             params = {'legacy': legacy}


### PR DESCRIPTION
The `legacy` param will be passed directly to the underlying /capacity
call. This will instruct the api to return capacity status for legacy
server types (baremetal_*) and/or new *.*.$arch "class" based types. The
current default is `only` which returns only the `baremetal_*`. In the
not-so-distant-future the default will change to `exclude`, so only
*.*.$arch types will be returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packet-python/39)
<!-- Reviewable:end -->
