### PR TITLE
Retrieve all objects from list_devices endpoint

### DIFF
--- a/packet/Manager.py
+++ b/packet/Manager.py
@@ -72,6 +72,24 @@ class Manager(BaseAPI):
             devices.append(device)
         return devices
 
+    def list_all_devices(self, project_id):
+        all_devices = list()
+        raw_devices = list()
+        page = 1
+        while True:
+            paginate = {"page": page}
+            data = self.call_api("projects/%s/devices" % project_id, params=paginate)
+            next = self.meta["next"]
+            raw_devices.extend(data["devices"])
+            if next is None:
+                break
+            else:
+                page += 1
+        for raw_device in raw_devices:
+            device = Device(raw_device, self)
+            all_devices.append(device)
+        return all_devices
+
     def create_device(
         self,
         project_id,

--- a/packet/Manager.py
+++ b/packet/Manager.py
@@ -73,7 +73,6 @@ class Manager(BaseAPI):
         return devices
 
     def list_all_devices(self, project_id):
-        all_devices = list()
         raw_devices = list()
         page = 1
         while True:
@@ -85,6 +84,8 @@ class Manager(BaseAPI):
                 break
             else:
                 page += 1
+
+        all_devices = list()
         for raw_device in raw_devices:
             device = Device(raw_device, self)
             all_devices.append(device)

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -71,6 +71,14 @@ class PacketManagerTest(unittest.TestCase):
             str(device)
             repr(device)
             self.assertIsInstance(device, packet.Device)
+    
+    # TODO figure out how to properly handle this test case
+    # def test_list_all_devices(self):
+    #     devices = self.manager.list_all_devices("438659f0")
+    #     for device in devices:
+    #         str(device)
+    #         repr(device)
+    #         self.assertIsInstance(device, packet.Device)
 
     def test_create_device(self):
         device = self.manager.create_device(

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -71,7 +71,7 @@ class PacketManagerTest(unittest.TestCase):
             str(device)
             repr(device)
             self.assertIsInstance(device, packet.Device)
-    
+
     # TODO figure out how to properly handle this test case
     # def test_list_all_devices(self):
     #     devices = self.manager.list_all_devices("438659f0")


### PR DESCRIPTION
The original PR was taking in `per_page` param to then list out all objects by hitting the api endpoints until `next` metadata was `null` (more specifically, calling the api `total % per_page` times). But, decided to just create a new function,`list_all_devices` that gets rid of `per_page`. This was due to the fact that the end goal is to return everything anyway and thus the number of items per page becomes arbitrary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packet-python/53)
<!-- Reviewable:end -->
