### PR TITLE
Add rescue action to devices

### DIFF
--- a/packet/Device.py
+++ b/packet/Device.py
@@ -79,6 +79,12 @@ class Device:
             "devices/%s/actions" % self.id, type="POST", params=params
         )
 
+    def rescue(self):
+        params = {"type": "rescue"}
+        return self.manager.call_api(
+            "devices/%s/actions" % self.id, type="POST", params=params
+        )
+
     def ips(self):
         return self.manager.list_device_ips(self.id)
 

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -108,6 +108,7 @@ class PacketManagerTest(unittest.TestCase):
         self.assertIsNone(device.power_off())
         self.assertIsNone(device.power_on())
         self.assertIsNone(device.reboot())
+        self.assertIsNone(device.rescue())
 
     def test_update_device(self):
         hostname = "updated hostname"

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -107,8 +107,8 @@ class PacketManagerTest(unittest.TestCase):
         device = self.manager.get_device("9dec7266")
         self.assertIsNone(device.power_off())
         self.assertIsNone(device.power_on())
-        self.assertIsNone(device.reboot())
         self.assertIsNone(device.rescue())
+        self.assertIsNone(device.reboot())
 
     def test_update_device(self):
         hostname = "updated hostname"


### PR DESCRIPTION
This pull request adds the rescue operation endpoint to the python client

https://www.packet.com/developers/api/#perform-an-action

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packet-python/59)
<!-- Reviewable:end -->
