### PR TITLE
Pin black to version 19.3b0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
   fmt_and_lint:
     image: python:3.6-alpine
     commands:
-      - pip install black pylama
+      - pip install black==19.3b0 pylama
       - black --check --diff .
       - pylama packet test setup.py
 


### PR DESCRIPTION
Black seems to have dependencies on musl-dev and gcc past this version. 
Hopefully this is just temporary. If we wanted to continue using the 
latest versions, we could instead add something like `apk add musl-dev 
gcc` but this increases the duration of the process significantly.

https://github.com/psf/black/issues/1112