### PR TITLE
Pin Black to a version that does not require gcc

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
   fmt_and_lint:
     image: python:3.6-alpine
     commands:
-      - pip install black pylama
+      - pip install black==19.3b0 pylama
       - black --check --diff .
       - pylama packet test setup.py
 


### PR DESCRIPTION
Recent versions of black require gcc to build a new regex dependency.
This may go away, so we'll just pin to a specific version black (which
is best practice anyway).

Related to https://github.com/psf/black/issues/1112.