### PR TITLE
project ssh keys: work around 404 bug

### DIFF
--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -26,3 +26,4 @@ from .Snapshot import Snapshot  # noqa
 from .Organization import Organization  # noqa
 from .Provider import Provider  # noqa
 from .baseapi import Error  # noqa
+from .baseapi import ResponseError  # noqa


### PR DESCRIPTION
When creating a project's SSH key with a project's API key, the SSH
key gets created but the response is a 404.

This patch works around that issue and allows the code to continue.

Upstreamed from https://github.com/input-output-hk/packet-python/commit/4baec99865cf97b0fbed6e7a7dc3ed6e438541dd


Note the backstory of this PR is in customer issue TUVD-0107-UIKB.