### PR TITLE
test Python 3.8 in Drone #82

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,10 @@
 matrix:
   PYTHON_VERSION:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 
 pipeline:
   fmt_and_lint:


### PR DESCRIPTION
add Python 3.8 to test matrix, remove Python 3.4

references #82