### PR TITLE
Adds fix for apis returning 'error' key

### DIFF
--- a/packet/baseapi.py
+++ b/packet/baseapi.py
@@ -23,6 +23,8 @@ class ResponseError(Error):
     def __init__(self, resp, data, exception=None):
         if not data:
             msg = "(empty response)"
+        elif "error" in data:
+            msg = data["error"]
         elif "errors" in data:
             msg = ", ".join(data["errors"])
         super().__init__("Error {0}: {1}".format(resp.status_code, msg), exception)


### PR DESCRIPTION
* Fixes a raise message of `UnboundLocalError: local variable 'msg' referenced before assignment` for api responses returning a single error key, such as `Error 401: Invalid authentication token` where `resp` and `data` are:
```
resp = <Response [401]>
data = {'error': 'Invalid authentication token'}
```
