### PR TITLE
check is Facility

### DIFF
--- a/packet/IPAddress.py
+++ b/packet/IPAddress.py
@@ -22,7 +22,8 @@ class IPAddress:
         self.customdata = data.get("customdata")
         self.project = data.get("project")
         self.project_lite = data.get("project_lite")
-        self.facility = Facility(data.get("facility"))
+        if data.get("facility") is not None:
+            self.facility = Facility(data.get("facility"))
         self.details = data.get("details")
         self.assigned_to = data.get("assigned_to")
         self.interface = data.get("interface")


### PR DESCRIPTION
I try to obtain ips for device without success:
```
Traceback (most recent call last):
  File "/workspace-private/zintegrationtestutils/packet.py", line 156, in is_public_address_ready
    ip_addresses = self.pkt_instance.ips()
  File "/usr/local/lib/python3.8/site-packages/packet/Device.py", line 106, in ips
    return self.manager.list_device_ips(self.id)
  File "/usr/local/lib/python3.8/site-packages/packet/Manager.py", line 368, in list_device_ips
    ip = IPAddress(jsoned, self)
  File "/usr/local/lib/python3.8/site-packages/packet/IPAddress.py", line 25, in __init__
    self.facility = Facility(data.get("facility"))
  File "/usr/local/lib/python3.8/site-packages/packet/Facility.py", line 7, in __init__
    self.id = data.get("id")
AttributeError: 'NoneType' object has no attribute 'get'
```

Seems, that facility field is null for my case:
```
"ip_addresses": [
		{
			"id": "c0b3e747-f85f-4abc-89c0-6683964a1d3c",
...
			"href": "/metal/v1/ips/c0b3e747-f85f-4abc-89c0-6683964a1d3c",
			"facility": null
		}
...
]
```


Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>