### PR TITLE
Add support empty Facility for IPAddress

### DIFF
--- a/packet/IPAddress.py
+++ b/packet/IPAddress.py
@@ -22,7 +22,8 @@ class IPAddress:
         self.customdata = data.get("customdata")
         self.project = data.get("project")
         self.project_lite = data.get("project_lite")
-        self.facility = Facility(data.get("facility"))
+        self.facility = \
+            Facility(data.get("facility")) if data.get("facility") else None
         self.details = data.get("details")
         self.assigned_to = data.get("assigned_to")
         self.interface = data.get("interface")

--- a/test/fixtures/get_projects_438659f0_ips.json
+++ b/test/fixtures/get_projects_438659f0_ips.json
@@ -1,0 +1,98 @@
+{"ip_addresses": [{
+	"id": "99d5d741-3756-4ebe-a014-34ea7a2e2be1",
+	"address_family": 4,
+	"netmask": "255.255.255.254",
+	"created_at": "2019-07-18T08:46:38Z",
+	"details": null,
+	"tags": [],
+	"public": true,
+	"cidr": 31,
+	"management": true,
+	"manageable": true,
+	"enabled": true,
+	"global_ip": null,
+	"customdata": {},
+	"project": {},
+	"project_lite": {},
+	"facility": {
+		"id": "8e6470b3-b75e-47d1-bb93-45b225750975",
+		"name": "Amsterdam, NL",
+		"code": "ams1",
+		"features": [
+			"baremetal",
+			"storage",
+			"global_ipv4",
+			"backend_transfer",
+			"layer_2"
+		],
+		"address": {
+			"href": "#0688e909-647e-4b21-bdf2-fc056d993fc5"
+		},
+		"ip_ranges": [
+			"2604:1380:2000::/36",
+			"147.75.204.0/23",
+			"147.75.100.0/22",
+			"147.75.80.0/22",
+			"147.75.32.0/23"
+		]
+	},
+	"assigned_to": {
+		"href": "/devices/54ffd20d-d972-4c8d-8628-9da18e67ae17"
+	},
+	"interface": {
+		"href": "/ports/02ea0556-df04-4554-b339-760a0d227b44"
+	},
+	"network": "147.75.84.94",
+	"address": "147.75.84.95",
+	"gateway": "147.75.84.94",
+	"href": "/ips/99d5d741-3756-4ebe-a014-34ea7a2e2be1"
+},
+{
+	"id": "99d5d741-3756-4ebe-a014-34ea7a2e2be2",
+	"address_family": 4,
+	"netmask": "255.255.255.254",
+	"created_at": "2019-07-18T08:46:38Z",
+	"details": null,
+	"tags": [],
+	"public": true,
+	"cidr": 31,
+	"management": true,
+	"manageable": true,
+	"enabled": true,
+	"global_ip": null,
+	"customdata": {},
+	"project": {},
+	"project_lite": {},
+	"facility": {
+		"id": "8e6470b3-b75e-47d1-bb93-45b225750975",
+		"name": "Amsterdam, NL",
+		"code": "ams1",
+		"features": [
+			"baremetal",
+			"storage",
+			"global_ipv4",
+			"backend_transfer",
+			"layer_2"
+		],
+		"address": {
+			"href": "#0688e909-647e-4b21-bdf2-fc056d993fc5"
+		},
+		"ip_ranges": [
+			"2604:1380:2000::/36",
+			"147.75.204.0/23",
+			"147.75.100.0/22",
+			"147.75.80.0/22",
+			"147.75.32.0/23"
+		]
+	},
+	"assigned_to": {
+		"href": "/devices/54ffd20d-d972-4c8d-8628-9da18e67ae17"
+	},
+	"interface": {
+		"href": "/ports/02ea0556-df04-4554-b339-760a0d227b44"
+	},
+	"network": "147.75.84.94",
+	"address": "147.75.84.95",
+	"gateway": "147.75.84.94",
+	"href": "/ips/99d5d741-3756-4ebe-a014-34ea7a2e2be1"
+}]}

--- a/test/fixtures/get_projects_438659f1_ips.json
+++ b/test/fixtures/get_projects_438659f1_ips.json
@@ -1,0 +1,77 @@
+{"ip_addresses": [{
+	"id": "99d5d741-3756-4ebe-a014-34ea7a2e2be1",
+	"address_family": 4,
+	"netmask": "255.255.255.254",
+	"created_at": "2019-07-18T08:46:38Z",
+	"details": null,
+	"tags": [],
+	"public": true,
+	"cidr": 31,
+	"management": true,
+	"manageable": true,
+	"enabled": true,
+	"global_ip": null,
+	"customdata": {},
+	"project": {},
+	"project_lite": {},
+	"facility": null,
+	"assigned_to": {
+		"href": "/devices/54ffd20d-d972-4c8d-8628-9da18e67ae17"
+	},
+	"interface": {
+		"href": "/ports/02ea0556-df04-4554-b339-760a0d227b44"
+	},
+	"network": "147.75.84.94",
+	"address": "147.75.84.95",
+	"gateway": "147.75.84.94",
+	"href": "/ips/99d5d741-3756-4ebe-a014-34ea7a2e2be1"
+},
+{
+	"id": "99d5d741-3756-4ebe-a014-34ea7a2e2be2",
+	"address_family": 4,
+	"netmask": "255.255.255.254",
+	"created_at": "2019-07-18T08:46:38Z",
+	"details": null,
+	"tags": [],
+	"public": true,
+	"cidr": 31,
+	"management": true,
+	"manageable": true,
+	"enabled": true,
+	"global_ip": null,
+	"customdata": {},
+	"project": {},
+	"project_lite": {},
+	"facility": {
+		"id": "8e6470b3-b75e-47d1-bb93-45b225750975",
+		"name": "Amsterdam, NL",
+		"code": "ams1",
+		"features": [
+			"baremetal",
+			"storage",
+			"global_ipv4",
+			"backend_transfer",
+			"layer_2"
+		],
+		"address": {
+			"href": "#0688e909-647e-4b21-bdf2-fc056d993fc5"
+		},
+		"ip_ranges": [
+			"2604:1380:2000::/36",
+			"147.75.204.0/23",
+			"147.75.100.0/22",
+			"147.75.80.0/22",
+			"147.75.32.0/23"
+		]
+	},
+	"assigned_to": {
+		"href": "/devices/54ffd20d-d972-4c8d-8628-9da18e67ae17"
+	},
+	"interface": {
+		"href": "/ports/02ea0556-df04-4554-b339-760a0d227b44"
+	},
+	"network": "147.75.84.94",
+	"address": "147.75.84.95",
+	"gateway": "147.75.84.94",
+	"href": "/ips/99d5d741-3756-4ebe-a014-34ea7a2e2be1"
+}]}

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -222,6 +222,19 @@ class PacketManagerTest(unittest.TestCase):
         ips = self.manager.list_device_ips("e123s")
         self.assertIsNotNone(ips)
 
+    def test_list_projects_ips(self):
+        ips = self.manager.list_project_ips("438659f0")
+        self.assertIsNotNone(ips)
+        for ip in ips:
+            self.assertIsInstance(ip.facility, packet.Facility)
+
+    def test_list_projects_ips_state_all(self):
+        ips = self.manager.list_project_ips(
+            "438659f1", params={"state": "all"})
+        self.assertIsNotNone(ips)
+        self.assertIsNone(ips[0].facility)
+        self.assertIsInstance(ips[1].facility, packet.Facility)
+
 
 class PacketMockManager(packet.Manager):
     def call_api(self, method, type="GET", params=None):


### PR DESCRIPTION
In case fetch ips for a project with `state=all` a server
    returns objects with null facility. It happens when IP in Pending
    status.