### PR TITLE
prepare v1.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 ### Fixed
 
-## [1.44.0] - 2021-05-20
+## [1.44.1] - 2021-09-20
+### Fixed
+- Fix metros URL used in Metro API lists #122
+- Catch TypeError when HardwareReservations do not have a device assignment #120
+
+## [1.44.0] - 2021-05-19
 ### Added
 - User-Agent header added to client requests #113
 - `Metro` class added (https://feedback.equinixmetal.com/changelog/new-metros-feature-live) #110

--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: LGPL-3.0-only
 
-"""library to interact with the Packet API"""
+"""library to interact with the Equinix Metal API"""
 
-__version__ = "1.44.0"
+__version__ = "1.44.1"
 __author__ = "Equinix Metal Engineers"
 __author_email__ = "support@equinixmetal.com"
 __license__ = "LGPL v3"


### PR DESCRIPTION
Prepares the following release:
https://github.com/packethost/packet-python/pull/124/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R17

Should match draft release: https://github.com/packethost/packet-python/releases/tag/untagged-210c609367aedfbb3204 (link will only work for maintainers)

^ This draft can be published upon merge.