### PR TITLE
prepare v1.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 ### Fixed
 
+## [1.44.2] - 2021-11-18
+### Fixed
+- Fix logic behind `validate_metro_capacity` #125
+
 ## [1.44.1] - 2021-09-20
 ### Fixed
 - Fix metros URL used in Metro API lists #122

--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -3,7 +3,7 @@
 
 """library to interact with the Equinix Metal API"""
 
-__version__ = "1.44.1"
+__version__ = "1.44.2"
 __author__ = "Equinix Metal Engineers"
 __author_email__ = "support@equinixmetal.com"
 __license__ = "LGPL v3"


### PR DESCRIPTION
Prepares the v1.44.2 release which only includes #125 (PR #126)

Reviewers: This follows the format of https://github.com/packethost/packet-python/pull/124, using the steps outlined in https://github.com/packethost/packet-python/blob/master/RELEASE.md (including the follow-up steps that I will perform).

